### PR TITLE
SDAS-1536: Specify awx installation vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Variables to control what version of AWX is checked out and installed.
 
 By default, this role will run the installation playbook included with AWX (which builds a set of containers and runs them). You can disable the playbook run by setting this variable to `no`.
 
+Variables to modify the installation.
+
+    awx_secret_key: tempsecretkey
+    postgres_data_dir: /opt/awx/pgdocker
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
+awx_secret_key: tempsecretkey
+postgres_data_dir: /opt/awx/pgdocker

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,11 @@
 ---
+- name: Ensure postgres_data_dir exists
+  file:
+    state: directory
+    path: "{{ postgres_data_dir }}"
+
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml"
+  command: "ansible-playbook -i inventory -e 'postgres_data_dir={{ postgres_data_dir }}' -e 'awx_secret_key={{ awx_secret_key }}' install.yml"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete


### PR DESCRIPTION
This commit forces values for postgres_data_dir and awx_secret_key so that they can be overridden.

Sane defaults are provided.

README updated.